### PR TITLE
feat: add IntrusionInspector DFIR triage tool for macOS and Linux

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+title: "[BUG]: "
+labels: ["bug"]
+---
+
+**Describe the bug**
+
+_A clear and concise description of what the bug is._
+
+**Steps to reproduce**
+
+1.
+
+**Expected behavior**
+
+_What you expected to happen._
+
+**Environment**
+
+- OS: (e.g., macOS 14.2, Ubuntu 22.04)
+- Bash version: (output of `bash --version`)
+- Profile used: (quick / standard / full)
+- Optional tools installed: (jq, yara, sqlite3)
+
+**Additional context**
+
+_Relevant output, error messages, or audit.log entries._

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature Request
+about: Suggest a new collector, analyzer, reporter, or improvement
+title: "[FR]: "
+labels: ["enhancement"]
+---
+
+**Is your feature request related to a problem?**
+
+_A clear description of the problem._
+
+**Describe the solution you'd like**
+
+_What you want to happen._
+
+**Component affected**
+
+- [ ] Collector
+- [ ] Analyzer
+- [ ] Reporter
+- [ ] Evidence handling
+- [ ] CLI / Engine
+- [ ] Documentation
+
+**Platform scope**
+
+- [ ] macOS
+- [ ] Linux
+- [ ] Both
+
+**Additional information**
+
+_Any other context, references to MITRE ATT&CK techniques, or relevant forensic artifacts._

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+<!-- 1-3 sentences describing the change -->
+
+## Changes
+- [ ] New feature
+- [ ] Bug fix
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Tests
+
+## Test Plan
+- [ ] `just lint` passes
+- [ ] `just shellcheck` passes
+- [ ] Tested on macOS
+- [ ] Tested on Linux
+- [ ] Manual triage run completed (`just quick`)
+
+## Cross-Platform Considerations
+<!-- Does this change use platform-specific commands? Describe macOS/Linux handling. -->
+
+## Security Considerations
+<!-- Does this change handle sensitive data, evidence files, or system access? Describe measures taken. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,170 @@
+# AI Agent Instructions
+
+## Project Context
+
+IntrusionInspector (Bash Edition) is a cross-platform DFIR (Digital Forensics and Incident Response) triage tool for macOS and Linux. It collects forensic artifacts from live endpoints, analyzes them with anomaly detection and IOC/Sigma/YARA scanning, maps findings to MITRE ATT&CK, and produces reports in HTML, JSON, CSV, and console formats.
+
+Key constraints:
+
+- **Language**: Bash 3.2+ (must run on macOS default bash — no associative arrays, no `${var,,}`)
+- **Dependencies**: Zero external dependencies for core functionality. `jq`, `sqlite3`, `yara`, and `zip` are optional enhancements
+- **Platforms**: macOS (BSD userland) and Linux (GNU userland, Debian/Ubuntu/RHEL/CentOS/Fedora)
+
+## Commands
+
+Use the `justfile` for all standard operations:
+
+```bash
+just                  # Show all available recipes
+just triage           # Full pipeline: collect + analyze + report (requires sudo)
+just collect          # Collect artifacts only (requires sudo)
+just analyze          # Analyze previously collected artifacts
+just report           # Generate reports from analysis results
+just verify           # Verify evidence integrity against manifest
+just quick            # Quick triage (5 collectors, ~30s)
+just standard         # Standard triage (16 collectors, ~2min)
+just full             # Full triage with YARA + file hashing (~5min)
+just lint             # bash -n syntax check on all scripts
+just shellcheck       # Static analysis with shellcheck
+just loc              # Lines of code count
+just clean            # Remove output directory
+```
+
+## Architecture
+
+```mermaid
+graph TD
+    CLI["intrusion-inspector.sh"] --> Engine["lib/engine.sh"]
+    Engine --> Collectors["lib/collectors/*.sh (16)"]
+    Engine --> Analyzers["lib/analyzers/*.sh (6)"]
+    Engine --> Reporters["lib/reporters/*.sh (4)"]
+    Engine --> Evidence["lib/evidence/*.sh"]
+    Collectors --> Raw["output/raw/*.json"]
+    Evidence --> Manifest["manifest.json + chain_of_custody.json"]
+    Raw --> Analyzers
+    Analyzers --> Analysis["output/analysis/*.json"]
+    Analysis --> Reporters
+    Reporters --> Reports["report.html, report.json, timeline.csv"]
+```
+
+**Pipeline flow**: CLI parses args and dispatches to `engine_*` functions. The engine loads a profile, runs collectors (writing JSON to `raw/`), seals evidence with SHA-256 manifests, runs analyzers (writing to `analysis/`), and generates reports.
+
+**Convention-based dispatch**: Collectors use `collect_<name>()`, reporters use `report_<format>()`. New modules are auto-discovered via glob sourcing in `engine.sh`.
+
+## Code Conventions
+
+### Bash 3.2 Compatibility (Critical)
+
+- **No associative arrays** (`declare -A`) — macOS ships Bash 3.2
+- **No `${var,,}` lowercasing** — use `echo "$var" | tr '[:upper:]' '[:lower:]'`
+- Use `case` functions as lookup tables instead of associative arrays (see `_suspicious_children()` and `_severity_weight()` in `config.sh`)
+
+### Shell Standards
+
+- `set -euo pipefail` in entry points
+- All variables quoted: `"$variable"` not `$variable`
+- `local` for all function variables
+- `[[ ]]` for conditionals, never `[ ]`
+- `readonly` for constants: `readonly MAX_RETRIES=3`
+- Prefer `printf` over `echo` for formatted output
+
+### Naming
+
+- Scripts: lowercase with underscores (`shell_history.sh`)
+- Functions: lowercase with underscores matching the module (`collect_shell_history`)
+- Local variables: lowercase with underscores (`local db_name`)
+- Constants: SCREAMING_SNAKE_CASE (`MAX_RISK_SCORE`)
+- Include guards: `_MODULE_LOADED` pattern
+
+### Documentation
+
+- Every file needs a header comment block (delimited by `# ===`) explaining purpose, architecture role, and platform support
+- Every function needs a multi-line `# ---` delimited comment with parameters, return values, and design notes
+- Comments explain _why_, not _what_
+
+### JSON Generation
+
+- Use `json_object`, `json_kvs`, `json_kvn`, `json_array` from `lib/core/json.sh` for building JSON
+- For bulk data (hundreds+ items), use `awk` for JSON generation instead of per-item shell function calls (see `processes.sh` for the pattern)
+- Use `json_write` to write JSON files
+- `jq` is optional — always provide a `grep`/`sed` fallback path
+
+## Common Tasks
+
+### Adding a New Collector
+
+1. Create `lib/collectors/my_collector.sh`
+2. Define `collect_my_collector()` taking `$1` = output_dir
+3. Use `write_collector_result` to save output to `raw/my_collector.json`
+4. Add `"my_collector"` to the relevant profile arrays in `profiles/*.conf`
+5. The engine auto-discovers it via glob sourcing — no registration needed
+
+### Adding an Analyzer
+
+1. Create `lib/analyzers/my_analyzer.sh`
+2. Define `analyze_my_analyzer()` taking `$1` = output_dir
+3. Write results to `analysis/my_analyzer.json`
+4. Add the analyzer call to `run_analyzers()` in `lib/engine.sh` (analyzers are explicitly ordered)
+
+### Adding a Reporter
+
+1. Create `lib/reporters/my_format_reporter.sh`
+2. Define `report_my_format()` taking `$1` = output_dir
+3. Auto-discovered when format `"my_format"` is requested via `--format`
+
+### Cross-Platform Testing
+
+- Use `has_cmd` to check tool availability before platform-specific calls
+- Use `compute_sha256`, `file_size`, `epoch_now` wrappers from `utils.sh` / `platform.sh`
+- Test on macOS (BSD `sed`, `stat`, `date`) and Linux (GNU equivalents)
+
+## Project Structure
+
+```
+intrusion-inspector.sh           # CLI entry point — argument parsing + dispatch
+lib/
+├── engine.sh                    # Pipeline orchestrator — sources + coordinates all modules
+├── core/
+│   ├── config.sh                # Constants, detection signatures, platform paths
+│   ├── json.sh                  # Pure-bash JSON builder (no jq dependency)
+│   ├── logging.sh               # Colored logging + audit trail
+│   ├── platform.sh              # OS detection, cross-platform wrappers
+│   └── utils.sh                 # General utilities (hashing, file ops)
+├── collectors/                  # 16 forensic artifact collectors
+├── analyzers/                   # 6 analysis engines
+├── reporters/                   # 4 report generators (html, json, csv, console)
+└── evidence/                    # SHA-256 manifests + chain of custody
+profiles/                        # Collection profiles (quick / standard / full)
+rules/                           # Detection rules (IOC YAML, Sigma YAML, YARA)
+```
+
+## Files to Avoid Modifying
+
+- `output/` — Generated evidence artifacts (gitignored)
+- `rules/iocs/`, `rules/sigma/`, `rules/yara/` — Example rule files (customize, don't delete)
+- `profiles/*.conf` — Only modify to add/remove collectors from profiles, not to change profile structure
+
+## Quality Gates
+
+Before committing:
+
+```bash
+just lint              # All scripts must pass bash -n syntax check
+just shellcheck        # All scripts must pass shellcheck static analysis
+```
+
+## Commit Messages
+
+Follow conventional commits:
+
+```
+feat(collector): add USB device collector for Linux
+fix(evidence): handle missing /proc on macOS
+perf(processes): use awk for bulk JSON generation
+docs(readme): update MITRE ATT&CK coverage table
+refactor(engine): extract profile loading into function
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
+
+Scopes: `collector`, `analyzer`, `reporter`, `evidence`, `engine`, `core`, `cli`, `readme`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to IntrusionInspector (Bash Edition)
+
+## Getting Started
+
+1. Clone the repo
+2. Ensure you have bash 3.2+ (macOS default) or 4.0+ (Linux)
+3. Run `just lint` to verify all scripts pass syntax checking
+4. Run `sudo just quick` to test a quick triage on your machine
+
+## Project Layout
+
+```
+intrusion-inspector.sh        # CLI entry point
+lib/
+├── core/                     # Shared libraries
+│   ├── platform.sh           # OS detection, cross-platform wrappers
+│   ├── json.sh               # Pure-bash JSON builder
+│   ├── logging.sh            # Colored logging + audit trail
+│   ├── config.sh             # Constants, defaults, detection lists
+│   └── utils.sh              # General utilities
+├── collectors/               # 16 forensic artifact collectors
+├── analyzers/                # 6 analysis engines
+├── reporters/                # 4 report generators
+├── evidence/                 # Evidence integrity + chain of custody
+└── engine.sh                 # Pipeline orchestrator
+profiles/                     # Collection profiles (quick/standard/full)
+rules/                        # IOC, Sigma, and YARA detection rules
+```
+
+## Development Workflow
+
+```bash
+just lint          # Syntax check all scripts
+just shellcheck    # Static analysis (requires shellcheck)
+just version       # Show version
+just quick         # Run quick triage for testing
+just clean         # Remove output directory
+```
+
+## Adding a Collector
+
+1. Create `lib/collectors/my_collector.sh`
+2. Define a function named `collect_my_collector()` that takes `$1` = output_dir
+3. Use `write_collector_result` to save output to `raw/my_collector.json`
+4. Add `"my_collector"` to the relevant profile arrays in `profiles/*.conf`
+5. The engine auto-discovers it via glob sourcing
+
+## Adding an Analyzer
+
+1. Create `lib/analyzers/my_analyzer.sh`
+2. Define `analyze_my_analyzer()` that takes `$1` = output_dir
+3. Write results to `analysis/my_analyzer.json`
+4. Add the analyzer call to `run_analyzers()` in `lib/engine.sh`
+
+## Adding a Reporter
+
+1. Create `lib/reporters/my_format_reporter.sh`
+2. Define `report_my_format()` that takes `$1` = output_dir
+3. It will be auto-discovered when format "my_format" is requested
+
+## Cross-Platform Guidelines
+
+This tool must run on both macOS and Linux. Key rules:
+
+- **No associative arrays** (`declare -A`) — macOS ships bash 3.2 which doesn't support them
+- **No `${var,,}` lowercasing** — use `echo "$var" | tr '[:upper:]' '[:lower:]'`
+- Use `has_cmd` to check for command availability before using platform-specific tools
+- Use the `compute_sha256`, `file_size`, `epoch_now` wrappers from `utils.sh` and `platform.sh`
+- Test on both macOS (BSD userland) and Linux (GNU userland) when possible
+
+## Code Style
+
+- Every file needs a header comment block explaining its purpose
+- Every function needs a multi-line comment with parameters and return values
+- Use `set -euo pipefail` in entry points
+- Use `local` for all function variables
+- Quote all variable expansions: `"$var"` not `$var`
+- Use `[[ ]]` not `[ ]` for conditionals
+- Prefer `printf` over `echo` for formatted output
+
+## Commit Messages
+
+Follow conventional commits:
+- `feat: add USB device collector for Linux`
+- `fix: handle missing /proc on macOS`
+- `perf: use awk for bulk JSON generation in processes collector`
+- `docs: add MITRE ATT&CK coverage table to README`

--- a/OWNERS.yaml
+++ b/OWNERS.yaml
@@ -1,0 +1,5 @@
+owners:
+  - kgaston
+
+reviewers:
+  - kgaston

--- a/README.md
+++ b/README.md
@@ -1,149 +1,363 @@
 # IntrusionInspector (Bash Edition)
 
-Cross-platform DFIR (Digital Forensics and Incident Response) triage tool for
-corporate endpoints, written entirely in bash. Collects forensic artifacts,
-analyzes them for indicators of compromise, and produces structured reports with
-MITRE ATT&CK mapping.
+[![Bash 3.2+](https://img.shields.io/badge/bash-3.2+-4eaa25?style=for-the-badge&logo=gnubash&logoColor=white)](https://www.gnu.org/software/bash/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green?style=for-the-badge)](LICENSE)
+[![MITRE ATT&CK](https://img.shields.io/badge/MITRE_ATT%26CK-mapped-ed1c24?style=for-the-badge)](https://attack.mitre.org)
+[![Platforms](https://img.shields.io/badge/platforms-macOS_|_Linux-333?style=for-the-badge)](#collectors)
+[![just](https://img.shields.io/badge/task_runner-just-de5fe9?style=for-the-badge)](https://just.systems)
 
-**Supported Platforms:** macOS, Linux (Debian/Ubuntu, RHEL/CentOS/Fedora)
+[![Collectors](https://img.shields.io/badge/collectors-16-0891b2?style=flat-square)](#collectors)
+[![Analyzers](https://img.shields.io/badge/analyzers-6-ca8a04?style=flat-square)](#analyzers)
+[![Reporters](https://img.shields.io/badge/reporters-4-6b21a8?style=flat-square)](#output-structure)
+[![ATT&CK Techniques](https://img.shields.io/badge/ATT%26CK_techniques-12_checks-dc2626?style=flat-square)](#mitre-attck-coverage)
+[![Evidence](https://img.shields.io/badge/evidence-SHA--256_manifest-2563eb?style=flat-square)](#evidence-integrity)
+[![Zero Dependencies](https://img.shields.io/badge/dependencies-zero_(bash_only)-brightgreen?style=flat-square)](#tech-stack)
+
+> Cross-platform DFIR artifact collection, analysis, and triage tool for endpoint incident response — implemented entirely in bash with zero external dependencies. Runs on macOS (including Bash 3.2) and Linux (Debian/Ubuntu, RHEL/CentOS/Fedora). Port of the Python [IntrusionInspector](https://github.com/kgaston/IntrusionInspector).
+
+## Overview
+
+IntrusionInspector automates the tedious, error-prone process of collecting forensic artifacts from live endpoints during incident response. Instead of manually running dozens of commands and copying output into reports, responders run a single command that collects 16 categories of artifacts, analyzes them for anomalies and known indicators of compromise, maps findings to the MITRE ATT&CK framework, and produces self-contained HTML reports ready for stakeholder review.
+
+The tool is designed for incident responders, SOC analysts, and DFIR practitioners who need to triage endpoints quickly without installing agents or dependencies. It ships as a single directory of bash scripts that can be copied to any macOS or Linux system and run immediately.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph input [Input Layer]
+        CLI["fa:fa-terminal CLI<br/>intrusion-inspector.sh"]
+        Profiles["fa:fa-file-alt Profiles<br/>quick / standard / full"]
+        Rules["fa:fa-shield-alt Detection Rules<br/>IOC / Sigma / YARA"]
+    end
+
+    subgraph orchestration [Orchestration]
+        Engine["fa:fa-cogs Engine<br/>lib/engine.sh"]
+        Platform["fa:fa-desktop Platform Detect<br/>macOS vs Linux"]
+    end
+
+    CLI --> Engine
+    Profiles --> Engine
+    Engine --> Platform
+
+    subgraph collect [Collection Phase — 16 Collectors]
+        direction TB
+        subgraph sysCollectors [System]
+            C1["System Info"]
+            C2["Processes"]
+            C3["Network"]
+            C4["Users"]
+        end
+        subgraph secCollectors [Security]
+            C5["Persistence"]
+            C6["Firewall"]
+            C7["Certificates"]
+            C8["Kernel Modules"]
+        end
+        subgraph artifactCollectors [Artifacts]
+            C9["Filesystem"]
+            C10["Logs"]
+            C11["Browser"]
+            C12["Shell History"]
+        end
+        subgraph deviceCollectors [Device / Env]
+            C13["USB Devices"]
+            C14["Software"]
+            C15["Environment"]
+            C16["Clipboard"]
+        end
+    end
+
+    Platform --> collect
+
+    subgraph integrity [Evidence Integrity]
+        Manifest["SHA-256 Manifest"]
+        Audit["Audit Log"]
+        CoC["Chain of Custody"]
+    end
+
+    collect --> integrity
+
+    subgraph analyze [Analysis Phase — 6 Analyzers]
+        IOC["IOC Scanner"]
+        YARA["YARA Engine"]
+        Sigma["Sigma Engine"]
+        Anomaly["Anomaly Detector"]
+        TL["Timeline Generator"]
+        MITRE["ATT&CK Mapper"]
+    end
+
+    Rules --> analyze
+    integrity --> analyze
+
+    subgraph output [Output Phase — 4 Reporters]
+        HTMLReport["HTML Report<br/>+ ATT&CK Matrix"]
+        JSONExport["JSON Export"]
+        CSVTimeline["CSV Super Timeline"]
+        ConsoleOut["ANSI Console"]
+    end
+
+    analyze --> output
+```
 
 ## Quick Start
 
 ```bash
-# Full triage (requires root)
-sudo ./intrusion-inspector.sh triage -o ./case_001 -p standard \
-    --case-id CASE001 --examiner "Jane Doe" -f html,json,csv,console
+# Clone
+git clone <repo-url> && cd LLR
 
-# Quick collection only
-sudo ./intrusion-inspector.sh collect -o ./case_001 -p quick
+# Full triage (collect + analyze + report) — requires root
+sudo bash intrusion-inspector.sh triage -o ./case_001/ \
+    --case-id "IR-2025-042" --examiner "K. Gaston"
 
-# Analyze existing collection with IOC rules
-sudo ./intrusion-inspector.sh analyze -i ./case_001 --iocs rules/iocs/
+# Quick triage (5 collectors, ~30 seconds)
+sudo bash intrusion-inspector.sh triage -o ./case_001/ -p quick
 
-# Generate a report from previous analysis
-./intrusion-inspector.sh report -i ./case_001 -f html
+# With IOC/Sigma/YARA rules
+sudo bash intrusion-inspector.sh triage -o ./case_001/ \
+    --iocs rules/iocs/ --sigma rules/sigma/ --yara rules/yara/
+
+# Encrypted evidence package for transport
+sudo bash intrusion-inspector.sh triage -o ./case_001/ \
+    --secure-output --password "CaseKey"
 
 # Verify evidence integrity
-./intrusion-inspector.sh verify -i ./case_001
+bash intrusion-inspector.sh verify -i ./case_001/
+
+# Or use just (if installed)
+just triage
+just quick
+just verify
 ```
 
-## Commands
+## CLI Commands
 
-| Command   | Description                                         |
-|-----------|-----------------------------------------------------|
-| `triage`  | Full pipeline: collect, analyze, report             |
-| `collect` | Collect forensic artifacts from the endpoint        |
-| `analyze` | Analyze previously collected artifacts              |
-| `report`  | Generate reports from analysis results              |
-| `verify`  | Verify evidence integrity against SHA-256 manifest  |
+| Command | Description |
+|---------|-------------|
+| `triage` | Full pipeline: collect + analyze + report |
+| `collect` | Collect artifacts only |
+| `analyze` | Analyze previously collected artifacts |
+| `report` | Generate reports from analysis results |
+| `verify` | Verify evidence integrity against manifest |
+
+### Key Flags
+
+| Flag | Commands | Description |
+|------|----------|-------------|
+| `--output, -o` | triage, collect | Output directory |
+| `--profile, -p` | triage, collect | Collection profile: `quick`, `standard`, `full` |
+| `--case-id` | triage, collect | Case identifier for chain of custody |
+| `--examiner` | triage, collect | Examiner name for chain of custody |
+| `--iocs` | triage, analyze | IOC rules path |
+| `--sigma` | triage, analyze | Sigma rules path |
+| `--yara` | triage, analyze | YARA rules path |
+| `--secure-output` | triage | Encrypt evidence package (ZIP + password) |
+| `--password` | triage | Password for encrypted package |
+| `--format, -f` | triage, report | Report format: `html`, `json`, `csv`, `console` |
+| `--verbose, -v` | all | Enable debug logging |
 
 ## Collection Profiles
 
-| Profile    | Collectors | Hash Files | YARA  | Timeout |
-|------------|-----------|------------|-------|---------|
-| `quick`    | 5         | No         | No    | 60s     |
-| `standard` | 16        | No         | No    | 300s    |
-| `full`     | 16        | Yes        | Yes   | 600s    |
+| Profile | Collectors | File Hashing | YARA | Typical Duration |
+|---------|-----------|--------------|------|------------------|
+| `quick` | 5 (system, processes, network, users, persistence) | No | No | ~30 seconds |
+| `standard` | 16 (all) | No | No | ~2 minutes |
+| `full` | 16 (all) | Yes | Yes | ~5 minutes |
 
-## Collectors (16)
+## Collectors
 
-| Collector           | Description                                    |
-|---------------------|------------------------------------------------|
-| `system_info`       | Hostname, OS, CPU, RAM, network interfaces     |
-| `processes`         | Running process enumeration                    |
-| `network`           | Connections, DNS config, ARP table             |
-| `users`             | User accounts, login history, active sessions  |
-| `persistence`       | Cron, systemd, launchd, login items            |
-| `filesystem`        | Temp directory scan, file metadata             |
-| `logs`              | System logs, auth logs, journal                |
-| `browser`           | Chrome, Firefox, Safari history (via sqlite3)  |
-| `shell_history`     | Bash, zsh, fish command history                |
-| `usb_devices`       | USB device history                             |
-| `installed_software`| dpkg, rpm, snap, brew, system_profiler         |
-| `kernel_modules`    | Loaded kernel modules/extensions               |
-| `firewall`          | iptables, nftables, ufw, pfctl rules           |
-| `environment`       | Environment variables (flags suspicious ones)  |
-| `clipboard`         | Clipboard contents with IOC detection          |
-| `certificates`      | System certificate stores                      |
+| Collector | macOS | Linux | Artifacts |
+|-----------|-------|-------|-----------|
+| System Info | `sysctl`, `sw_vers`, `system_profiler` | `/proc`, `uname`, `hostnamectl` | Hostname, OS, IPs, CPU, RAM |
+| Processes | `ps aux` | `ps aux`, `/proc` | PID, cmdline, parent, user |
+| Network | `netstat`, `lsof`, `arp` | `ss`, `netstat`, `/proc/net` | Connections, DNS, ARP |
+| Users | `dscl`, `last` | `/etc/passwd`, `utmp`, `last` | Accounts, logins, groups |
+| Persistence | `launchctl`, `cron` | `cron`, `systemd`, `/etc/init.d` | Autostart mechanisms |
+| Filesystem | `/tmp`, recent items | `/tmp`, `/var/tmp`, `/dev/shm` | Suspicious files |
+| Logs | `log show` (unified log) | `syslog`, `auth.log`, `journal` | Security logs |
+| Browser | Chrome, Firefox, Safari | Chrome, Firefox | History, downloads |
+| Shell History | `~/.zsh_history`, `~/.bash_history` | `~/.bash_history`, `~/.zsh_history` | Command history |
+| USB Devices | `system_profiler SPUSBDataType` | `syslog`, `lsusb` | Device history |
+| Software | `system_profiler`, `brew` | `dpkg`, `rpm`, `snap`, `flatpak` | Installed apps |
+| Kernel Modules | `kextstat` | `lsmod`, `/proc/modules` | Loaded modules |
+| Firewall | `pfctl` | `iptables`, `nftables`, `ufw` | Firewall rules |
+| Environment | `env`, `launchctl` | `env`, `/proc/*/environ` | Environment variables |
+| Clipboard | `pbpaste` | `xclip`, `xsel`, `wl-paste` | Clipboard contents |
+| Certificates | `security`, Keychain | `/etc/ssl`, `openssl` | Certificate stores |
 
-## Analyzers (6)
+## Analyzers
 
-| Analyzer            | Description                                    |
-|---------------------|------------------------------------------------|
-| IOC Scanner         | Match artifacts against YAML IOC rules         |
-| Anomaly Detector    | 12 heuristic checks with MITRE mapping         |
-| Timeline            | Aggregate and sort timestamps                  |
-| Sigma Scanner       | Basic Sigma rule matching                      |
-| YARA Scanner        | Pattern matching via `yara` CLI (optional)     |
-| MITRE Mapper        | ATT&CK technique aggregation and risk scoring  |
+| Analyzer | Description | Detection Method |
+|----------|-------------|-----------------|
+| IOC Scanner | Matches artifacts against YAML-defined indicators | Hash, IP, domain, filepath, process name matching |
+| YARA Scanner | Runs YARA rules against collected files | Pattern matching (optional, requires `yara` CLI) |
+| Sigma Scanner | Evaluates Sigma detection rules against logs | Field-based log analysis |
+| Anomaly Detector | Heuristic checks with MITRE ATT&CK mapping | LOLBins, parent-child, temp execution, etc. |
+| Timeline Generator | Super timeline from all collectors | Timestamp aggregation and sorting |
+| MITRE ATT&CK Mapper | Aggregates technique IDs, generates Navigator layer | Cross-analyzer technique correlation |
 
-## Report Formats
+## MITRE ATT&CK Coverage
 
-- **HTML** — Self-contained dark-theme report with risk score, findings table,
-  MITRE summary, and collector overview
-- **JSON** — Full structured export with ATT&CK Navigator layer
-- **CSV** — Timeline and findings spreadsheets
-- **Console** — ANSI-colored terminal output
+The anomaly detector maps findings to ATT&CK techniques:
 
-## Output Layout
-
-```
-output/
-├── raw/                          # One JSON per collector
-├── analysis/                     # Analysis results
-│   ├── anomaly_detector.json
-│   ├── timeline.json
-│   ├── ioc_scanner.json
-│   └── mitre_attack_summary.json
-├── report.html
-├── report.json
-├── timeline.csv
-├── findings.csv
-├── attack_navigator_layer.json
-├── manifest.json                 # SHA-256 evidence manifest
-├── audit.log                     # Timestamped audit log
-└── chain_of_custody.json         # Case metadata
-```
+| Check | Techniques | Severity |
+|-------|-----------|----------|
+| LOLBins usage | T1218, T1216 | Medium |
+| Unusual parent-child processes | T1055, T1036 | High |
+| Temp directory execution | T1204 | High |
+| Suspicious scheduled tasks | T1053 | Medium |
+| Unusual network connections | T1071 | Medium |
+| Base64-encoded commands | T1027, T1059 | High |
+| Unusual services | T1543 | Medium |
+| PATH hijacking | T1574 | High |
+| Rogue certificates | T1553 | Medium |
+| Suspicious kernel modules | T1547, T1014 | Critical |
+| Clipboard monitoring | T1115 | Low |
+| Firewall tampering | T1562 | High |
 
 ## Evidence Integrity
 
-Every file produced during collection is SHA-256 hashed into `manifest.json`.
-Use the `verify` command to check that no files have been tampered with since
-collection.
+Every collection produces:
 
-## Dependencies
+- **`manifest.json`** — SHA-256 hash of every collected file, plus a hash of the manifest itself stored in chain of custody
+- **`audit.log`** — Timestamped log of every action taken during collection
+- **`chain_of_custody.json`** — Case ID, examiner, system IDs, timestamps, manifest hash, artifact and file counts, tool version
 
-**Required:** bash 4+, coreutils, awk, grep, sed, find
+Verify integrity at any time:
 
-**Optional (enhanced functionality):**
-- `jq` — Pretty-printed JSON output
-- `sqlite3` — Browser history collection
-- `yara` — YARA rule scanning
-- `zip` — Encrypted evidence packages
+```bash
+bash intrusion-inspector.sh verify -i ./case_001/
+# or
+just verify
+```
 
-## Environment Variables
+## Output Structure
 
-| Variable        | Default    | Description                   |
-|-----------------|------------|-------------------------------|
-| `II_OUTPUT_DIR` | `./output` | Default output directory      |
-| `II_CASE_ID`    | (empty)    | Default case identifier       |
-| `II_EXAMINER`   | (empty)    | Default examiner name         |
-| `LOG_LEVEL`     | `INFO`     | Log level: DEBUG/INFO/WARN/ERROR |
+```
+case_001/
+├── raw/                          # Raw collector output (JSON per collector)
+│   ├── system_info.json
+│   ├── processes.json
+│   ├── network.json
+│   └── ...                       # 16 collector files total
+├── analysis/                     # Analysis results
+│   ├── anomaly_detector.json
+│   ├── timeline.json
+│   ├── ioc_scanner.json          # (if IOC rules provided)
+│   ├── sigma_scanner.json        # (if Sigma rules provided)
+│   ├── yara_scanner.json         # (if YARA rules provided)
+│   └── mitre_attack_summary.json
+├── report.html                   # Full HTML report with ATT&CK matrix
+├── report.json                   # JSON export for SIEM ingestion
+├── timeline.csv                  # CSV super timeline
+├── findings.csv                  # CSV findings export
+├── attack_navigator_layer.json   # ATT&CK Navigator layer
+├── manifest.json                 # Evidence integrity manifest
+├── audit.log                     # Collection audit log
+└── chain_of_custody.json         # Chain of custody metadata
+```
 
 ## Project Structure
 
 ```
-intrusion-inspector.sh        # CLI entry point
-lib/
-  core/                       # Platform detection, JSON, logging, config
-  collectors/                 # 16 forensic artifact collectors
-  analyzers/                  # 6 analysis engines
-  reporters/                  # 4 report generators
-  evidence/                   # Integrity and chain of custody
-profiles/                     # Collection profiles (quick/standard/full)
-rules/                        # Detection rules (IOC, Sigma, YARA)
+LLR/
+├── intrusion-inspector.sh        # CLI entry point
+├── justfile                      # Task runner recipes
+├── profiles/                     # Collection profiles
+│   ├── quick.conf
+│   ├── standard.conf
+│   └── full.conf
+├── rules/                        # Detection rules
+│   ├── iocs/                     # IOC definitions (YAML)
+│   ├── sigma/                    # Sigma rules (YAML)
+│   └── yara/                     # YARA rules
+├── lib/
+│   ├── engine.sh                 # Pipeline orchestrator
+│   ├── core/                     # Shared libraries
+│   │   ├── platform.sh           # OS detection, cross-platform wrappers
+│   │   ├── json.sh               # Pure-bash JSON builder
+│   │   ├── logging.sh            # Colored logging + audit trail
+│   │   ├── config.sh             # Constants, defaults, detection lists
+│   │   └── utils.sh              # General utilities
+│   ├── collectors/               # 16 forensic artifact collectors
+│   │   ├── system_info.sh
+│   │   ├── processes.sh
+│   │   ├── network.sh
+│   │   └── ...
+│   ├── analyzers/                # 6 analysis engines
+│   │   ├── anomaly_detector.sh
+│   │   ├── ioc_scanner.sh
+│   │   ├── timeline.sh
+│   │   └── ...
+│   ├── reporters/                # 4 report generators
+│   │   ├── html_reporter.sh
+│   │   ├── json_reporter.sh
+│   │   ├── csv_reporter.sh
+│   │   └── console_reporter.sh
+│   └── evidence/                 # Evidence integrity
+│       ├── integrity.sh
+│       └── chain_of_custody.sh
+├── AGENTS.md                    # AI agent development guide
+├── CONTRIBUTING.md              # Contributor guidelines
+├── OWNERS.yaml                  # Code ownership
+├── LICENSE                      # MIT License
+└── README.md
 ```
+
+## Development
+
+```bash
+just lint              # Syntax check all scripts
+just shellcheck        # Static analysis (requires shellcheck)
+just loc               # Lines of code
+just list-collectors   # List all collector functions
+just list-analyzers    # List all analyzer functions
+just list-reporters    # List all reporter functions
+just version           # Show version
+just clean             # Remove output directory
+```
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|-----------|
+| Language | Bash 3.2+ (macOS compatible) |
+| Task Runner | [just](https://just.systems) |
+| JSON Building | Pure-bash (`lib/core/json.sh`) |
+| JSON Parsing | `jq` (optional, graceful fallback to `grep`/`sed`) |
+| Bulk Data Processing | `awk` (for performance-critical JSON generation) |
+| Hashing | `shasum -a 256` (macOS) / `sha256sum` (Linux) |
+| YARA Scanning | `yara` CLI (optional) |
+| Encrypted Output | `zip -P` (optional) |
+| Platform Detection | `uname`, `/proc`, `sw_vers` |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `II_OUTPUT_DIR` | `./output` | Default output directory |
+| `II_CASE_ID` | (empty) | Default case identifier |
+| `II_EXAMINER` | (empty) | Default examiner name |
+| `LOG_FORMAT` | `color` | Logging format: `color`, `plain` |
+| `LOG_LEVEL` | `INFO` | Log level: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards, and how to add new collectors, analyzers, and reporters.
+
+## Differences from the Python Version
+
+| Feature | Python | Bash |
+|---------|--------|------|
+| Language | Python 3.12+ | Bash 3.2+ |
+| Dependencies | psutil, rich, jinja2, pydantic, etc. | Zero (bash + standard Unix tools) |
+| JSON handling | Built-in `json` module | Pure-bash builder + optional `jq` |
+| HTML reports | Jinja2 templates | Heredoc templates |
+| Console output | Rich library | ANSI escape codes |
+| Deployment | `uv sync` + pip packages | Copy script directory |
+| Windows support | Yes | No (macOS + Linux only) |
+| Process introspection | psutil (cross-platform) | `ps` + `/proc` |
 
 ## License
 
-MIT
+[MIT](LICENSE) — Copyright (c) 2022 Kody Gaston

--- a/justfile
+++ b/justfile
@@ -1,0 +1,117 @@
+# =============================================================================
+# IntrusionInspector (Bash Edition) — Task Runner
+# =============================================================================
+#
+# Provides convenient shortcuts for common operations. Requires `just`:
+#   macOS:  brew install just
+#   Linux:  cargo install just  (or distro package)
+#
+# Usage:
+#   just              — show available recipes
+#   just triage       — full pipeline (collect + analyze + report)
+#   just collect      — collect artifacts only
+#   just verify       — verify evidence integrity
+#
+# =============================================================================
+
+# Default recipe — show all available commands
+default:
+    @just --list
+
+# ── Collection & Triage ──────────────────────────────────────────────────────
+
+# Full triage pipeline: collect + analyze + report
+triage profile="standard" output="./output":
+    sudo bash intrusion-inspector.sh triage -o {{output}} -p {{profile}} -f html,json,csv,console
+
+# Collect artifacts only
+collect profile="standard" output="./output":
+    sudo bash intrusion-inspector.sh collect -o {{output}} -p {{profile}}
+
+# Analyze previously collected artifacts
+analyze input="./output":
+    bash intrusion-inspector.sh analyze -i {{input}}
+
+# Analyze with all rule types
+analyze-full input="./output":
+    bash intrusion-inspector.sh analyze -i {{input}} --iocs rules/iocs/ --sigma rules/sigma/ --yara rules/yara/
+
+# Generate reports from analysis results
+report input="./output" format="html":
+    bash intrusion-inspector.sh report -i {{input}} -f {{format}}
+
+# Verify evidence integrity against manifest
+verify input="./output":
+    bash intrusion-inspector.sh verify -i {{input}}
+
+# Full triage with IOC/Sigma/YARA rules
+triage-full profile="standard" output="./output":
+    sudo bash intrusion-inspector.sh triage -o {{output}} -p {{profile}} \
+        --iocs rules/iocs/ --sigma rules/sigma/ --yara rules/yara/ \
+        -f html,json,csv,console
+
+# Triage with encrypted evidence package
+triage-secure profile="standard" output="./output":
+    sudo bash intrusion-inspector.sh triage -o {{output}} -p {{profile}} \
+        --secure-output -f html,json,csv,console
+
+# ── Quick Profiles ───────────────────────────────────────────────────────────
+
+# Quick triage (5 collectors, ~30 seconds)
+quick output="./output":
+    sudo bash intrusion-inspector.sh triage -o {{output}} -p quick -f html,console
+
+# Standard triage (all 16 collectors, ~2 minutes)
+standard output="./output":
+    sudo bash intrusion-inspector.sh triage -o {{output}} -p standard -f html,json,csv,console
+
+# Full triage with file hashing and YARA (all 16 collectors, ~5 minutes)
+full output="./output":
+    sudo bash intrusion-inspector.sh triage -o {{output}} -p full \
+        --yara rules/yara/ -f html,json,csv,console
+
+# ── Development ──────────────────────────────────────────────────────────────
+
+# Check all bash scripts for syntax errors
+lint:
+    @echo "Checking bash syntax across all scripts..."
+    @find . -name '*.sh' -not -path './output/*' | while read f; do \
+        bash -n "$f" 2>&1 && echo "  OK: $f" || echo "  FAIL: $f"; \
+    done
+    @echo "Done."
+
+# Run shellcheck on all scripts (requires shellcheck)
+shellcheck:
+    @echo "Running shellcheck..."
+    @find . -name '*.sh' -not -path './output/*' -exec shellcheck -x {} +
+
+# Count lines of code across the project
+loc:
+    @echo "Lines of code (excluding output/):"
+    @find . -name '*.sh' -not -path './output/*' | xargs wc -l | tail -1
+
+# List all collector functions
+list-collectors:
+    @grep -rh '^collect_' lib/collectors/*.sh | sed 's/() {//' | sort
+
+# List all analyzer functions
+list-analyzers:
+    @grep -rh '^analyze_' lib/analyzers/*.sh | sed 's/() {//' | sort
+
+# List all reporter functions
+list-reporters:
+    @grep -rh '^report_' lib/reporters/*.sh | sed 's/() {//' | sort
+
+# Show tool version
+version:
+    @bash intrusion-inspector.sh --version
+
+# ── Cleanup ──────────────────────────────────────────────────────────────────
+
+# Remove output directory
+clean:
+    rm -rf ./output/
+
+# Remove all generated artifacts
+clean-all:
+    rm -rf ./output/ ./*.zip

--- a/lib/engine.sh
+++ b/lib/engine.sh
@@ -309,9 +309,18 @@ engine_collect() {
 
     run_collectors "$output_dir"
 
-    # Seal evidence: hash all files and record end timestamp
+    # Count total artifacts across all collector outputs for the COC record
+    local total_artifacts=0
+    for rf in "${output_dir}/raw"/*.json; do
+        [[ -f "$rf" ]] || continue
+        local ac
+        ac="$(grep -o '"artifact_count": [0-9]*' "$rf" 2>/dev/null | head -1 | sed 's/.*: //')"
+        total_artifacts=$(( total_artifacts + ${ac:-0} ))
+    done
+
+    # Seal evidence: hash all files, then record end timestamp + manifest hash
     generate_manifest "$output_dir"
-    finalize_chain_of_custody "$output_dir"
+    finalize_chain_of_custody "$output_dir" "$total_artifacts"
 
     local global_end
     global_end="$(epoch_now)"
@@ -429,9 +438,18 @@ engine_triage() {
     run_analyzers "$output_dir" "$iocs_path" "$sigma_path" "$yara_path"
     run_reporters "$output_dir" "$formats"
 
-    # Seal evidence after all phases complete
+    # Count total artifacts across all collector outputs for the COC record
+    local total_artifacts=0
+    for rf in "${output_dir}/raw"/*.json; do
+        [[ -f "$rf" ]] || continue
+        local ac
+        ac="$(grep -o '"artifact_count": [0-9]*' "$rf" 2>/dev/null | head -1 | sed 's/.*: //')"
+        total_artifacts=$(( total_artifacts + ${ac:-0} ))
+    done
+
+    # Seal evidence after all phases complete — manifest first, then COC
     generate_manifest "$output_dir"
-    finalize_chain_of_custody "$output_dir"
+    finalize_chain_of_custody "$output_dir" "$total_artifacts"
 
     # Optionally package everything into a password-encrypted ZIP
     if [[ "$secure" == "true" ]]; then

--- a/lib/evidence/chain_of_custody.sh
+++ b/lib/evidence/chain_of_custody.sh
@@ -40,6 +40,11 @@
 # Set by init_chain_of_custody and reused by finalize_chain_of_custody.
 _COC_FILE=""
 
+# These globals are set by generate_manifest() in integrity.sh so that
+# finalize_chain_of_custody can embed them in the final COC record.
+MANIFEST_SHA256="${MANIFEST_SHA256:-}"
+MANIFEST_FILE_COUNT="${MANIFEST_FILE_COUNT:-0}"
+
 # -----------------------------------------------------------------------------
 # init_chain_of_custody — Create the chain of custody record
 #
@@ -78,38 +83,58 @@ init_chain_of_custody() {
 }
 
 # -----------------------------------------------------------------------------
-# finalize_chain_of_custody — Stamp the collection end time
+# finalize_chain_of_custody — Stamp end time, embed manifest hash and counts
 #
 # Parameters:
-#   $1  output_dir — Root output directory (used to locate the file if
-#                    _COC_FILE wasn't set, e.g., in standalone analyze runs)
+#   $1  output_dir      — Root output directory (used to locate the file if
+#                          _COC_FILE wasn't set, e.g., in standalone analyze runs)
+#   $2  total_artifacts  — (optional) Total artifact count across all collectors
 #
-# Updates the collection_end field in chain_of_custody.json to the current
-# UTC timestamp. Uses jq for clean JSON mutation when available; falls back
-# to bash string substitution (safe because the initial value is always an
-# empty string literal written by init_chain_of_custody).
+# Updates the chain_of_custody.json with:
+#   - collection_end     — UTC timestamp when collection finished
+#   - manifest_sha256    — SHA-256 hash of the manifest.json file itself
+#   - total_artifacts    — Sum of artifacts across all collectors
+#   - total_files        — Number of evidence files recorded in the manifest
+#
+# Uses jq for clean JSON mutation when available; falls back to rebuilding
+# the JSON from scratch when jq is not installed.
 # -----------------------------------------------------------------------------
 finalize_chain_of_custody() {
     local output_dir="$1"
+    local total_artifacts="${2:-0}"
 
-    # Handle the case where finalize is called without a prior init
     [[ -z "$_COC_FILE" ]] && _COC_FILE="${output_dir}/chain_of_custody.json"
     [[ -f "$_COC_FILE" ]] || return 0
+
+    local end_ts
+    end_ts="$(utc_now)"
 
     local content
     content="$(cat "$_COC_FILE")"
 
-    # Patch collection_end from "" to the current UTC timestamp
     if has_cmd jq; then
-        echo "$content" | jq --arg ts "$(utc_now)" '.collection_end = $ts' > "$_COC_FILE" 2>/dev/null
+        echo "$content" | jq \
+            --arg ts "$end_ts" \
+            --arg mhash "${MANIFEST_SHA256:-}" \
+            --argjson ta "${total_artifacts:-0}" \
+            --argjson tf "${MANIFEST_FILE_COUNT:-0}" \
+            '.collection_end = $ts | .manifest_sha256 = $mhash | .total_artifacts = $ta | .total_files = $tf' \
+            > "$_COC_FILE" 2>/dev/null
     else
-        # Bash string replacement — relies on the known empty-string pattern
-        # written by init_chain_of_custody above
-        local end_ts
-        end_ts="$(utc_now)"
+        # Patch collection_end via string replacement
         content="${content/\"collection_end\": \"\"/\"collection_end\": \"${end_ts}\"}"
+
+        # Inject new fields before the closing brace. This is safe because
+        # init_chain_of_custody writes well-formed JSON with a final "}" on its own line.
+        local extra=""
+        extra+="\"manifest_sha256\": \"${MANIFEST_SHA256:-}\","
+        extra+="\"total_artifacts\": ${total_artifacts:-0},"
+        extra+="\"total_files\": ${MANIFEST_FILE_COUNT:-0}"
+
+        # Replace the last "}" with extra fields + "}"
+        content="${content%\}*}${extra}}"
         printf '%s\n' "$content" > "$_COC_FILE"
     fi
 
-    audit_log "chain_of_custody" "Finalized at $(utc_now)"
+    audit_log "chain_of_custody" "Finalized: manifest_sha256=${MANIFEST_SHA256:-none}, artifacts=${total_artifacts}, files=${MANIFEST_FILE_COUNT:-0}"
 }

--- a/lib/evidence/integrity.sh
+++ b/lib/evidence/integrity.sh
@@ -83,6 +83,12 @@ generate_manifest() {
     json_write "$manifest_file" "$manifest"
     audit_log "manifest_generated" "SHA-256 manifest for ${#entries[@]} files"
     log_success "Manifest: ${#entries[@]} files hashed"
+
+    # Store manifest metadata in global variables for chain_of_custody to pick up.
+    # The manifest hash lets the COC record independently verify that the manifest
+    # itself hasn't been altered after signing.
+    MANIFEST_FILE_COUNT="${#entries[@]}"
+    MANIFEST_SHA256="$(compute_sha256 "$manifest_file")"
 }
 
 # -----------------------------------------------------------------------------

--- a/lib/reporters/console_reporter.sh
+++ b/lib/reporters/console_reporter.sh
@@ -1,128 +1,225 @@
 #!/usr/bin/env bash
 # =============================================================================
-# lib/reporters/console_reporter.sh — ANSI-Colored Terminal Report
+# lib/reporters/console_reporter.sh — Rich ANSI Terminal Report
 # =============================================================================
 #
-# Renders the triage report directly to the terminal with ANSI color codes and
-# Unicode box-drawing characters for a polished CLI experience. Designed for
-# quick visual triage by incident responders who want an immediate summary
-# without opening a browser or spreadsheet.
+# Produces a comprehensive terminal report using ANSI escape codes for color
+# and formatting. Modelled after the Python IntrusionInspector Rich-based
+# console reporter, but implemented with pure bash and printf.
 #
-# Architecture role:
-#   One of four reporter modules (json, csv, html, console) dispatched by
-#   run_reporters() via format "console" → function report_console().
+# All output goes to stderr so it does not interfere with stdout-based
+# piping or JSON output. The report includes:
 #
-# Output sections (mirroring the HTML report):
-#   1. Box-drawn header banner with version
-#   2. System information (hostname, OS, architecture)
-#   3. Color-coded risk score (green ≤20, yellow 21-50, red >50)
-#   4. MITRE ATT&CK technique list with arrow indicators
-#   5. Severity-colored findings list (critical/high=red, medium=yellow, etc.)
-#   6. Collector summary table (name, artifact count, duration)
-#
-# All output goes to stderr so it doesn't interfere with stdout piping.
-# Color variables ($_CLR_*) are defined in lib/core/logging.sh.
+#   1. Header banner with tool name and case metadata
+#   2. Risk score with severity label and color coding
+#   3. Findings summary breakdown by severity level
+#   4. Detailed findings list with index numbers and MITRE references
+#   5. System information overview
+#   6. MITRE ATT&CK technique tree grouped by tactic
+#   7. Collection summary table with artifact counts and durations
 #
 # =============================================================================
 
 # -----------------------------------------------------------------------------
-# report_console — Render a color-coded report summary to the terminal
+# report_console — Generate the full ANSI-colored terminal report
 #
 # Parameters:
 #   $1  output_dir — Root output directory containing raw/ and analysis/
 #
-# Reads the same JSON sources as the HTML reporter but renders to stderr
-# using printf with ANSI escape sequences. No file output is produced.
+# Output:
+#   All output to stderr via printf/echo >&2
+#
+# Design:
+#   Uses the _CLR_* color variables from logging.sh for consistent theming.
+#   Box-drawing characters (Unicode) create visual structure. Each section
+#   is a self-contained block with clear headers for easy scanning.
 # -----------------------------------------------------------------------------
 report_console() {
     local output_dir="$1"
 
-    # ── Extract system info and risk metrics ──
-    local hostname_val="" os_val="" arch_val="" risk_score=0 technique_count=0
-
+    # ── Extract system info ──
+    local hostname_val="" os_val="" os_version="" arch_val=""
     if [[ -f "${output_dir}/raw/system_info.json" ]]; then
         hostname_val="$(grep -o '"hostname": "[^"]*"' "${output_dir}/raw/system_info.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
         os_val="$(grep -o '"os_name": "[^"]*"' "${output_dir}/raw/system_info.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+        os_version="$(grep -o '"os_version": "[^"]*"' "${output_dir}/raw/system_info.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
         arch_val="$(grep -o '"architecture": "[^"]*"' "${output_dir}/raw/system_info.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
     fi
 
+    # ── Extract risk metrics ──
+    local risk_score=0 technique_count=0
     if [[ -f "${output_dir}/analysis/mitre_attack_summary.json" ]]; then
         risk_score="$(grep -o '"risk_score": [0-9]*' "${output_dir}/analysis/mitre_attack_summary.json" 2>/dev/null | head -1 | sed 's/.*: //')"
         technique_count="$(grep -o '"technique_count": [0-9]*' "${output_dir}/analysis/mitre_attack_summary.json" 2>/dev/null | head -1 | sed 's/.*: //')"
     fi
 
-    # Map risk score to ANSI color: green (safe), yellow (warning), red (danger)
-    local risk_clr="$_CLR_GREEN"
-    [[ "${risk_score:-0}" -gt 20 ]] && risk_clr="$_CLR_YELLOW"
-    [[ "${risk_score:-0}" -gt 50 ]] && risk_clr="$_CLR_RED"
-
-    # ── Report header — Unicode box-drawing banner ──
-    printf '\n%b' "$_CLR_CYAN" >&2
-    printf '╔══════════════════════════════════════════════════════════╗\n' >&2
-    printf '║          IntrusionInspector Report v%-20s ║\n' "${VERSION}" >&2
-    printf '╚══════════════════════════════════════════════════════════╝\n' >&2
-    printf '%b\n' "$_CLR_RESET" >&2
-
-    # ── System information section ──
-    printf '%b  System Information%b\n' "$_CLR_BOLD" "$_CLR_RESET" >&2
-    printf '  %-16s %s\n' "Hostname:" "${hostname_val:-—}" >&2
-    printf '  %-16s %s\n' "OS:" "${os_val:-—}" >&2
-    printf '  %-16s %s\n' "Architecture:" "${arch_val:-—}" >&2
-    printf '\n' >&2
-
-    # ── Risk score with severity coloring ──
-    printf '%b  Risk Score: %b%s%b / %s%b\n\n' "$_CLR_BOLD" "$risk_clr" "${risk_score:-0}" "$_CLR_RESET" "$MAX_RISK_SCORE" "$_CLR_RESET" >&2
-
-    # ── MITRE ATT&CK technique listing ──
-    printf '%b  MITRE ATT&CK: %s techniques detected%b\n' "$_CLR_BOLD" "${technique_count:-0}" "$_CLR_RESET" >&2
-
-    # List each detected technique ID with a cyan arrow prefix
-    if [[ -f "${output_dir}/analysis/mitre_attack_summary.json" ]]; then
-        while IFS= read -r tid; do
-            tid="$(echo "$tid" | tr -d '"' | sed 's/.*: //')"
-            [[ -z "$tid" ]] && continue
-            printf '    %b→%b %s\n' "$_CLR_CYAN" "$_CLR_RESET" "$tid" >&2
-        done < <(grep -o '"technique_id": "[^"]*"' "${output_dir}/analysis/mitre_attack_summary.json" 2>/dev/null)
+    # ── Extract case info ──
+    local case_id="" examiner=""
+    if [[ -f "${output_dir}/chain_of_custody.json" ]]; then
+        case_id="$(grep -o '"case_id": "[^"]*"' "${output_dir}/chain_of_custody.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+        examiner="$(grep -o '"examiner": "[^"]*"' "${output_dir}/chain_of_custody.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
     fi
-    printf '\n' >&2
 
-    # ── Findings section — severity-colored list ──
-    printf '%b  Findings%b\n' "$_CLR_BOLD" "$_CLR_RESET" >&2
-
-    local total_findings=0
+    # ── Count findings by severity ──
+    local count_critical=0 count_high=0 count_medium=0 count_low=0 count_info=0
     for af in "${output_dir}/analysis"/*.json; do
         [[ -f "$af" ]] || continue
         [[ "$(basename "$af")" == "mitre_attack_summary.json" || "$(basename "$af")" == "timeline.json" ]] && continue
-
-        # Extract individual finding objects and render each one
-        while IFS= read -r line; do
-            local sev desc
-            sev="$(echo "$line" | grep -o '"severity": "[^"]*"' | head -1 | sed 's/.*": "//;s/"//')"
-            desc="$(echo "$line" | grep -o '"description": "[^"]*"' | head -1 | sed 's/.*": "//;s/"//')"
-            [[ -z "$sev" ]] && continue
-
-            # Map severity to ANSI color for visual triage
-            local sev_clr
+        while IFS= read -r sev; do
+            sev="$(echo "$sev" | sed 's/.*": "//;s/"//')"
             case "$sev" in
-                critical) sev_clr="$_CLR_RED" ;;
-                high)     sev_clr="$_CLR_RED" ;;
-                medium)   sev_clr="$_CLR_YELLOW" ;;
-                low)      sev_clr="$_CLR_DIM" ;;
-                *)        sev_clr="$_CLR_RESET" ;;
+                critical) count_critical=$((count_critical + 1)) ;;
+                high)     count_high=$((count_high + 1)) ;;
+                medium)   count_medium=$((count_medium + 1)) ;;
+                low)      count_low=$((count_low + 1)) ;;
+                info)     count_info=$((count_info + 1)) ;;
             esac
-
-            printf '    %b[%-8s]%b %s\n' "$sev_clr" "$sev" "$_CLR_RESET" "$desc" >&2
-            total_findings=$((total_findings + 1))
-        done < <(grep -o '{[^{}]*"severity"[^{}]*}' "$af" 2>/dev/null)
+        done < <(grep -o '"severity": "[^"]*"' "$af" 2>/dev/null)
     done
+    local total_findings=$((count_critical + count_high + count_medium + count_low + count_info))
 
-    [[ "$total_findings" -eq 0 ]] && printf '    %b(no findings)%b\n' "$_CLR_DIM" "$_CLR_RESET" >&2
+    # Risk level label and color
+    local risk_clr="$_CLR_GREEN" risk_label="CLEAN"
+    if [[ "${risk_score:-0}" -ge 70 ]]; then
+        risk_clr="$_CLR_RED"; risk_label="CRITICAL"
+    elif [[ "${risk_score:-0}" -ge 40 ]]; then
+        risk_clr="$_CLR_RED"; risk_label="HIGH"
+    elif [[ "${risk_score:-0}" -ge 20 ]]; then
+        risk_clr="$_CLR_YELLOW"; risk_label="MEDIUM"
+    elif [[ "${risk_score:-0}" -ge 5 ]]; then
+        risk_clr="$_CLR_CYAN"; risk_label="LOW"
+    fi
 
+    # ════════════════════════════════════════════════════════════════
+    # Section 1: Header banner
+    # ════════════════════════════════════════════════════════════════
+    printf '\n' >&2
+    printf '%b╔══════════════════════════════════════════════════════════════╗%b\n' "$_CLR_CYAN" "$_CLR_RESET" >&2
+    printf '%b║      IntrusionInspector — DFIR Triage Report  v%-12s ║%b\n' "$_CLR_CYAN" "${VERSION}" "$_CLR_RESET" >&2
+    printf '%b╚══════════════════════════════════════════════════════════════╝%b\n' "$_CLR_CYAN" "$_CLR_RESET" >&2
+
+    [[ -n "$case_id" ]] && printf '  %bCase ID:%b    %s\n' "$_CLR_BOLD" "$_CLR_RESET" "$case_id" >&2
+    [[ -n "$examiner" ]] && printf '  %bExaminer:%b   %s\n' "$_CLR_BOLD" "$_CLR_RESET" "$examiner" >&2
+    [[ -n "$hostname_val" ]] && printf '  %bHost:%b       %s\n' "$_CLR_BOLD" "$_CLR_RESET" "$hostname_val" >&2
+    [[ -n "$os_val" ]] && printf '  %bOS:%b         %s %s (%s)\n' "$_CLR_BOLD" "$_CLR_RESET" "$os_val" "$os_version" "$arch_val" >&2
     printf '\n' >&2
 
-    # ── Collector summary table ──
-    # Tabular layout showing what each collector gathered and how long it took
-    printf '%b  Collection Summary%b\n' "$_CLR_BOLD" "$_CLR_RESET" >&2
+    # ════════════════════════════════════════════════════════════════
+    # Section 2: Risk score
+    # ════════════════════════════════════════════════════════════════
+    printf '  %bRisk Score:%b  %b%s/100 (%s)%b\n' \
+        "$_CLR_BOLD" "$_CLR_RESET" "$risk_clr" "${risk_score:-0}" "$risk_label" "$_CLR_RESET" >&2
+    printf '\n' >&2
+
+    # ════════════════════════════════════════════════════════════════
+    # Section 3: Findings summary by severity
+    # ════════════════════════════════════════════════════════════════
+    printf '  %bFindings Summary%b\n' "$_CLR_BOLD" "$_CLR_RESET" >&2
+    printf '  %-12s %s\n' "Severity" "Count" >&2
+    printf '  %-12s %s\n' "────────────" "─────" >&2
+    printf '  %b%-12s%b %d\n' "$_CLR_RED"    "CRITICAL" "$_CLR_RESET" "$count_critical" >&2
+    printf '  %b%-12s%b %d\n' "$_CLR_RED"    "HIGH"     "$_CLR_RESET" "$count_high" >&2
+    printf '  %b%-12s%b %d\n' "$_CLR_YELLOW" "MEDIUM"   "$_CLR_RESET" "$count_medium" >&2
+    printf '  %b%-12s%b %d\n' "$_CLR_CYAN"   "LOW"      "$_CLR_RESET" "$count_low" >&2
+    printf '  %b%-12s%b %d\n' "$_CLR_DIM"    "INFO"     "$_CLR_RESET" "$count_info" >&2
+    printf '  %-12s %s\n' "────────────" "─────" >&2
+    printf '  %-12s %d\n' "Total" "$total_findings" >&2
+    printf '\n' >&2
+
+    # ════════════════════════════════════════════════════════════════
+    # Section 4: Detailed findings with index numbers
+    # ════════════════════════════════════════════════════════════════
+    printf '  %bDetailed Findings%b\n' "$_CLR_BOLD" "$_CLR_RESET" >&2
+
+    if [[ "$total_findings" -eq 0 ]]; then
+        printf '    %b(no findings detected)%b\n' "$_CLR_GREEN" "$_CLR_RESET" >&2
+    else
+        local finding_idx=0
+        for af in "${output_dir}/analysis"/*.json; do
+            [[ -f "$af" ]] || continue
+            [[ "$(basename "$af")" == "mitre_attack_summary.json" || "$(basename "$af")" == "timeline.json" ]] && continue
+
+            while IFS= read -r line; do
+                local sev desc technique source_name
+                sev="$(echo "$line" | grep -o '"severity": "[^"]*"' | head -1 | sed 's/.*": "//;s/"//')"
+                desc="$(echo "$line" | grep -o '"description": "[^"]*"' | head -1 | sed 's/.*": "//;s/"//')"
+                technique="$(echo "$line" | grep -o '"mitre_technique": "[^"]*"' | head -1 | sed 's/.*": "//;s/"//')"
+                source_name="$(echo "$line" | grep -o '"source": "[^"]*"' | head -1 | sed 's/.*": "//;s/"//')"
+                [[ -z "$sev" ]] && continue
+
+                finding_idx=$((finding_idx + 1))
+                local sev_clr
+                case "$sev" in
+                    critical) sev_clr="$_CLR_RED" ;;
+                    high)     sev_clr="$_CLR_RED" ;;
+                    medium)   sev_clr="$_CLR_YELLOW" ;;
+                    low)      sev_clr="$_CLR_CYAN" ;;
+                    *)        sev_clr="$_CLR_DIM" ;;
+                esac
+
+                local mitre_str=""
+                [[ -n "$technique" ]] && mitre_str=" [${technique}]"
+
+                printf '\n    %b%2d. [%-8s]%s%b %s\n' \
+                    "$sev_clr" "$finding_idx" "$sev" "$mitre_str" "$_CLR_RESET" "$desc" >&2
+                [[ -n "$source_name" ]] && printf '        %bSource: %s%b\n' "$_CLR_DIM" "$source_name" "$_CLR_RESET" >&2
+            done < <(grep -o '{[^{}]*"severity"[^{}]*}' "$af" 2>/dev/null)
+        done
+    fi
+    printf '\n' >&2
+
+    # ════════════════════════════════════════════════════════════════
+    # Section 5: System information
+    # ════════════════════════════════════════════════════════════════
+    if [[ -f "${output_dir}/raw/system_info.json" ]]; then
+        printf '  %bSystem Overview%b\n' "$_CLR_BOLD" "$_CLR_RESET" >&2
+        printf '  %-18s %s\n' "Field" "Value" >&2
+        printf '  %-18s %s\n' "──────────────────" "──────────────────────────────────" >&2
+
+        # Read key-value pairs from the system info artifact
+        while IFS= read -r kv; do
+            local key val
+            key="$(echo "$kv" | sed 's/^"//;s/": .*//')"
+            val="$(echo "$kv" | sed 's/^[^:]*: "//;s/"$//' | sed 's/^[^:]*: //')"
+            # Skip complex/nested fields and internal fields
+            [[ "$key" == "network_interfaces" || "$key" == "artifacts" ]] && continue
+            [[ "$key" == "collector_name" || "$key" == "platform" || "$key" == "collected_at" ]] && continue
+            [[ "$key" == "duration_seconds" || "$key" == "artifact_count" ]] && continue
+            printf '  %-18s %s\n' "$key" "$val" >&2
+        done < <(grep -oE '"[a-z_]+": ("[^"]*"|[0-9]+)' "${output_dir}/raw/system_info.json" 2>/dev/null | head -20)
+
+        printf '\n' >&2
+    fi
+
+    # ════════════════════════════════════════════════════════════════
+    # Section 6: MITRE ATT&CK technique tree
+    # ════════════════════════════════════════════════════════════════
+    if [[ -f "${output_dir}/analysis/mitre_attack_summary.json" ]] && [[ "${technique_count:-0}" -gt 0 ]]; then
+        printf '  %bMITRE ATT&CK Coverage%b  (%s techniques)\n' "$_CLR_BOLD" "$_CLR_RESET" "${technique_count}" >&2
+
+        # Group techniques by tactic for tree display
+        local current_tactic=""
+        while IFS= read -r line; do
+            local tid tactic tcount
+            tid="$(echo "$line" | grep -o '"technique_id": "[^"]*"' | sed 's/.*": "//;s/"//')"
+            tactic="$(echo "$line" | grep -o '"tactic": "[^"]*"' | sed 's/.*": "//;s/"//')"
+            tcount="$(echo "$line" | grep -o '"count": [0-9]*' | sed 's/.*: //')"
+            [[ -z "$tid" ]] && continue
+
+            # Print tactic header when tactic changes
+            if [[ "$tactic" != "$current_tactic" ]]; then
+                current_tactic="$tactic"
+                printf '    %b├─ %s%b\n' "$_CLR_BOLD" "$tactic" "$_CLR_RESET" >&2
+            fi
+            printf '    │  %b→%b %s  (%s findings)\n' "$_CLR_CYAN" "$_CLR_RESET" "$tid" "${tcount:-0}" >&2
+        done < <(grep -o '{[^{}]*"technique_id"[^{}]*}' "${output_dir}/analysis/mitre_attack_summary.json" 2>/dev/null)
+        printf '\n' >&2
+    fi
+
+    # ════════════════════════════════════════════════════════════════
+    # Section 7: Collection summary table
+    # ════════════════════════════════════════════════════════════════
+    printf '  %bCollection Summary%b\n' "$_CLR_BOLD" "$_CLR_RESET" >&2
     printf '  %-24s %10s %10s\n' "Collector" "Artifacts" "Duration" >&2
     printf '  %-24s %10s %10s\n' "────────────────────────" "─────────" "────────" >&2
 

--- a/lib/reporters/html_reporter.sh
+++ b/lib/reporters/html_reporter.sh
@@ -1,35 +1,46 @@
 #!/usr/bin/env bash
 # =============================================================================
-# lib/reporters/html_reporter.sh — Self-Contained HTML Report Generator
+# lib/reporters/html_reporter.sh — Full-Featured Self-Contained HTML Report
 # =============================================================================
 #
-# Produces a single-file HTML report with an embedded dark-theme CSS design.
-# The report is fully self-contained (no external CSS/JS dependencies) so it
-# can be opened in any browser, attached to tickets, or emailed as-is.
+# Produces a single-file HTML report modelled after the Python IntrusionInspector
+# HTML reporter. The report is fully self-contained — all CSS and JavaScript are
+# inline — so it can be opened in any modern browser, attached to tickets, or
+# emailed without external dependencies.
 #
 # Architecture role:
 #   One of four reporter modules (json, csv, html, console) dispatched by
 #   run_reporters() via format "html" → function report_html(). This is the
-#   default report format and typically the primary deliverable for incident
-#   responders.
+#   default and primary report format for incident responders.
 #
-# Report sections:
-#   1. System information cards (hostname, OS, architecture, kernel)
-#   2. Risk score gauge with color-coded ring (green/amber/red)
-#   3. Summary cards (total findings, MITRE technique count, case ID)
-#   4. Findings table (severity, description, MITRE technique, source)
-#   5. Collection summary table (collector name, artifact count, duration)
-#   6. Footer with examiner name and tool version
+# Report sections (matching the Python version):
+#   1. Sticky navigation bar with section jump links
+#   2. Executive summary cards (hostname, OS, architecture, kernel)
+#   3. Risk score gauge with SVG ring and severity label
+#   4. Findings summary by severity (critical/high/medium/low/info counts)
+#   5. MITRE ATT&CK technique list grouped by tactic
+#   6. Detailed findings table (sortable, collapsible by severity)
+#   7. System overview table
+#   8. Collector summary table (name, artifact count, duration)
+#   9. Timeline section with search/filter functionality
+#  10. Footer with case metadata and tool version
 #
 # Data extraction:
-#   Uses grep+sed to parse JSON values since jq may not be available. This
-#   is intentionally simple pattern matching — the JSON files are produced
-#   by our own json.sh builder and have predictable formatting.
+#   Uses grep+sed to parse JSON values since jq may not be available. This is
+#   intentionally simple pattern matching — the JSON files are produced by our
+#   own json.sh builder and have predictable formatting.
+#
+# Design decisions:
+#   - CSS custom properties (variables) enable consistent dark-theme styling.
+#   - JavaScript is minimal and progressive — the report is fully readable
+#     without JS, but JS adds search, filter, and section toggle features.
+#   - The heredoc is split: quoted (HTMLEOF) for static template, unquoted
+#     (EOF) for dynamic bash-interpolated content.
 #
 # =============================================================================
 
 # -----------------------------------------------------------------------------
-# report_html — Build and write the self-contained HTML report
+# report_html — Build and write the full-featured HTML report
 #
 # Parameters:
 #   $1  output_dir — Root output directory containing raw/ and analysis/
@@ -37,53 +48,98 @@
 # Outputs:
 #   ${output_dir}/report.html — Single-file dark-themed HTML report
 #
-# The function is structured in phases:
-#   1. Extract scalar values from JSON files (system info, risk score, etc.)
-#   2. Count total findings across all analyzer outputs
-#   3. Build HTML table rows for findings and collector summaries
-#   4. Emit the HTML document using heredocs (static template + dynamic data)
+# Phases:
+#   1. Extract system info, risk metrics, and case metadata from JSON files
+#   2. Build severity breakdown counts for the summary cards
+#   3. Build MITRE ATT&CK technique rows grouped by tactic
+#   4. Build findings table rows with severity-based CSS classes
+#   5. Build collector summary table rows
+#   6. Build timeline entries for the searchable timeline section
+#   7. Emit the complete HTML document via heredocs
 # -----------------------------------------------------------------------------
 report_html() {
     local output_dir="$1"
     local html_file="${output_dir}/report.html"
 
     # ── Phase 1: Extract system info and risk metrics ──
-    local hostname_val="" os_val="" arch_val="" kernel_val="" risk_score=0
-    local technique_count=0 finding_count=0
+    local hostname_val="" os_val="" os_version="" arch_val="" kernel_val=""
+    local cpu_model="" ram_mb="" boot_time="" uptime_sec=""
+    local risk_score=0 technique_count=0 finding_count=0
 
-    # Parse system_info.json for endpoint identification fields
     if [[ -f "${output_dir}/raw/system_info.json" ]]; then
-        hostname_val="$(grep -o '"hostname": "[^"]*"' "${output_dir}/raw/system_info.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
-        os_val="$(grep -o '"os_name": "[^"]*"' "${output_dir}/raw/system_info.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
-        arch_val="$(grep -o '"architecture": "[^"]*"' "${output_dir}/raw/system_info.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
-        kernel_val="$(grep -o '"kernel_version": "[^"]*"' "${output_dir}/raw/system_info.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+        local sysfile="${output_dir}/raw/system_info.json"
+        hostname_val="$(grep -o '"hostname": "[^"]*"' "$sysfile" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+        os_val="$(grep -o '"os_name": "[^"]*"' "$sysfile" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+        os_version="$(grep -o '"os_version": "[^"]*"' "$sysfile" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+        arch_val="$(grep -o '"architecture": "[^"]*"' "$sysfile" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+        kernel_val="$(grep -o '"kernel_version": "[^"]*"' "$sysfile" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+        cpu_model="$(grep -o '"cpu_model": "[^"]*"' "$sysfile" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+        ram_mb="$(grep -o '"ram_total_mb": [0-9]*' "$sysfile" 2>/dev/null | head -1 | sed 's/.*: //')"
+        boot_time="$(grep -o '"boot_time": "[^"]*"' "$sysfile" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+        uptime_sec="$(grep -o '"uptime_seconds": [0-9]*' "$sysfile" 2>/dev/null | head -1 | sed 's/.*: //')"
     fi
 
-    # Parse MITRE summary for risk score and technique count
     if [[ -f "${output_dir}/analysis/mitre_attack_summary.json" ]]; then
         risk_score="$(grep -o '"risk_score": [0-9]*' "${output_dir}/analysis/mitre_attack_summary.json" 2>/dev/null | head -1 | sed 's/.*: //')"
         technique_count="$(grep -o '"technique_count": [0-9]*' "${output_dir}/analysis/mitre_attack_summary.json" 2>/dev/null | head -1 | sed 's/.*: //')"
     fi
 
-    # ── Phase 2: Aggregate total finding count across all analyzers ──
+    local case_id="" examiner="" collection_start="" collection_end=""
+    if [[ -f "${output_dir}/chain_of_custody.json" ]]; then
+        case_id="$(grep -o '"case_id": "[^"]*"' "${output_dir}/chain_of_custody.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+        examiner="$(grep -o '"examiner": "[^"]*"' "${output_dir}/chain_of_custody.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+        collection_start="$(grep -o '"collection_start": "[^"]*"' "${output_dir}/chain_of_custody.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+        collection_end="$(grep -o '"collection_end": "[^"]*"' "${output_dir}/chain_of_custody.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+    fi
+
+    # ── Phase 2: Severity breakdown counts ──
+    local count_critical=0 count_high=0 count_medium=0 count_low=0 count_info=0
+
     for af in "${output_dir}/analysis"/*.json; do
         [[ -f "$af" ]] || continue
         [[ "$(basename "$af")" == "mitre_attack_summary.json" || "$(basename "$af")" == "timeline.json" ]] && continue
-        local fc
-        fc="$(grep -o '"finding_count": [0-9]*' "$af" 2>/dev/null | head -1 | sed 's/.*: //')"
-        finding_count=$(( finding_count + ${fc:-0} ))
+        while IFS= read -r sev; do
+            sev="$(echo "$sev" | sed 's/.*": "//;s/"//')"
+            case "$sev" in
+                critical) count_critical=$((count_critical + 1)) ;;
+                high)     count_high=$((count_high + 1)) ;;
+                medium)   count_medium=$((count_medium + 1)) ;;
+                low)      count_low=$((count_low + 1)) ;;
+                info)     count_info=$((count_info + 1)) ;;
+            esac
+        done < <(grep -o '"severity": "[^"]*"' "$af" 2>/dev/null)
     done
+    finding_count=$((count_critical + count_high + count_medium + count_low + count_info))
 
-    # Color-code the risk score ring: green (0-20), amber (21-50), red (51+)
-    local risk_color="#4caf50"
-    [[ "${risk_score:-0}" -gt 20 ]] && risk_color="#ff9800"
-    [[ "${risk_score:-0}" -gt 50 ]] && risk_color="#f44336"
+    # Risk level label and SVG color
+    local risk_label="CLEAN" risk_color="#4caf50"
+    if [[ "${risk_score:-0}" -ge 70 ]]; then
+        risk_label="CRITICAL"; risk_color="#dc2626"
+    elif [[ "${risk_score:-0}" -ge 40 ]]; then
+        risk_label="HIGH"; risk_color="#ea580c"
+    elif [[ "${risk_score:-0}" -ge 20 ]]; then
+        risk_label="MEDIUM"; risk_color="#ca8a04"
+    elif [[ "${risk_score:-0}" -ge 5 ]]; then
+        risk_label="LOW"; risk_color="#0891b2"
+    fi
 
-    # ── Phase 3: Build HTML table rows for findings ──
-    # Each finding object is extracted via a grep pattern that captures
-    # single-depth JSON objects containing a "severity" key. Fields are
-    # then parsed individually from each matched object.
+    # ── Phase 3: MITRE ATT&CK technique rows ──
+    local mitre_rows=""
+    if [[ -f "${output_dir}/analysis/mitre_attack_summary.json" ]]; then
+        while IFS= read -r line; do
+            local tid tactic tcount
+            tid="$(echo "$line" | grep -o '"technique_id": "[^"]*"' | sed 's/.*": "//;s/"//')"
+            tactic="$(echo "$line" | grep -o '"tactic": "[^"]*"' | sed 's/.*": "//;s/"//')"
+            tcount="$(echo "$line" | grep -o '"count": [0-9]*' | sed 's/.*: //')"
+            [[ -z "$tid" ]] && continue
+            mitre_rows+="<tr><td><code>${tid}</code></td><td>${tactic}</td><td>${tcount:-0}</td>"
+            mitre_rows+="<td><a href=\"https://attack.mitre.org/techniques/${tid//.//}/\" target=\"_blank\" rel=\"noopener\">View</a></td></tr>"
+        done < <(grep -o '{[^{}]*"technique_id"[^{}]*}' "${output_dir}/analysis/mitre_attack_summary.json" 2>/dev/null)
+    fi
+
+    # ── Phase 4: Findings table rows ──
     local findings_rows=""
+    local finding_idx=0
     for af in "${output_dir}/analysis"/*.json; do
         [[ -f "$af" ]] || continue
         [[ "$(basename "$af")" == "mitre_attack_summary.json" || "$(basename "$af")" == "timeline.json" ]] && continue
@@ -91,41 +147,60 @@ report_html() {
         analyzer_name="$(basename "$af" .json)"
 
         while IFS= read -r line; do
-            local sev desc technique
+            local sev desc technique detail check
             sev="$(echo "$line" | grep -o '"severity": "[^"]*"' | head -1 | sed 's/.*": "//;s/"//')"
             desc="$(echo "$line" | grep -o '"description": "[^"]*"' | head -1 | sed 's/.*": "//;s/"//')"
             technique="$(echo "$line" | grep -o '"mitre_technique": "[^"]*"' | head -1 | sed 's/.*": "//;s/"//')"
+            detail="$(echo "$line" | grep -o '"detail": "[^"]*"' | head -1 | sed 's/.*": "//;s/"//')"
             [[ -z "$sev" ]] && continue
 
-            # CSS class maps to severity-based color (sev-critical, sev-high, etc.)
+            finding_idx=$((finding_idx + 1))
             local sev_class="sev-${sev}"
-            findings_rows+="<tr><td class=\"${sev_class}\">${sev}</td><td>${desc}</td><td>${technique:-—}</td><td>${analyzer_name}</td></tr>"
+            local technique_link=""
+            if [[ -n "$technique" ]]; then
+                technique_link="<a href=\"https://attack.mitre.org/techniques/${technique//.//}/\" target=\"_blank\" rel=\"noopener\">${technique}</a>"
+            else
+                technique_link="—"
+            fi
+            findings_rows+="<tr class=\"finding-row\" data-severity=\"${sev}\">"
+            findings_rows+="<td>${finding_idx}</td>"
+            findings_rows+="<td><span class=\"sev-badge ${sev_class}\">${sev}</span></td>"
+            findings_rows+="<td>${desc}</td>"
+            findings_rows+="<td>${technique_link}</td>"
+            findings_rows+="<td>${analyzer_name}</td>"
+            findings_rows+="</tr>"
         done < <(grep -o '{[^{}]*"severity"[^{}]*}' "$af" 2>/dev/null)
     done
 
-    # ── Phase 4: Build HTML table rows for collector summary ──
-    # Shows artifact count and collection duration for each collector
+    # ── Phase 5: Collector summary rows ──
     local collector_rows=""
+    local total_artifacts=0
     for rf in "${output_dir}/raw"/*.json; do
         [[ -f "$rf" ]] || continue
         local cname acount dur
         cname="$(basename "$rf" .json)"
         acount="$(grep -o '"artifact_count": [0-9]*' "$rf" 2>/dev/null | head -1 | sed 's/.*: //')"
         dur="$(grep -o '"duration_seconds": [0-9]*' "$rf" 2>/dev/null | head -1 | sed 's/.*: //')"
+        total_artifacts=$(( total_artifacts + ${acount:-0} ))
         collector_rows+="<tr><td>${cname}</td><td>${acount:-0}</td><td>${dur:-0}s</td></tr>"
     done
 
-    # Extract case metadata from chain of custody for the report header/footer
-    local case_id="" examiner=""
-    if [[ -f "${output_dir}/chain_of_custody.json" ]]; then
-        case_id="$(grep -o '"case_id": "[^"]*"' "${output_dir}/chain_of_custody.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
-        examiner="$(grep -o '"examiner": "[^"]*"' "${output_dir}/chain_of_custody.json" 2>/dev/null | head -1 | sed 's/.*": "//;s/"//')"
+    # ── Phase 6: Timeline entries ──
+    local timeline_rows=""
+    if [[ -f "${output_dir}/analysis/timeline.json" ]]; then
+        while IFS= read -r line; do
+            local ts src etype edetail
+            ts="$(echo "$line" | grep -o '"timestamp": "[^"]*"' | head -1 | sed 's/.*": "//;s/"//')"
+            src="$(echo "$line" | grep -o '"source": "[^"]*"' | head -1 | sed 's/.*": "//;s/"//')"
+            etype="$(echo "$line" | grep -o '"event_type": "[^"]*"' | head -1 | sed 's/.*": "//;s/"//')"
+            [[ -z "$ts" ]] && continue
+            timeline_rows+="<tr class=\"timeline-row\"><td>${ts}</td><td>${src}</td><td>${etype:-event}</td></tr>"
+        done < <(grep -o '{[^{}]*"timestamp"[^{}]*}' "${output_dir}/analysis/timeline.json" 2>/dev/null | head -200)
     fi
 
-    # ── Phase 5: Emit the HTML document ──
-    # The document is split into two heredocs:
-    #   1. HTMLEOF (quoted) — static HTML/CSS template, no variable expansion
-    #   2. EOF (unquoted) — dynamic content with bash variable interpolation
+    # ── Phase 7: Emit HTML document ──
+
+    # Part 1: Static HTML/CSS/JS template (quoted heredoc — no variable expansion)
     cat > "$html_file" <<'HTMLEOF'
 <!DOCTYPE html>
 <html lang="en">
@@ -134,83 +209,266 @@ report_html() {
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>IntrusionInspector Report</title>
 <style>
-:root{--bg:#1a1a2e;--surface:#16213e;--card:#0f3460;--text:#e0e0e0;--text-dim:#8888aa;--accent:#00d4ff;--danger:#f44336;--warn:#ff9800;--ok:#4caf50}
+:root{
+  --bg:#111827;--surface:#1f2937;--card:#1e293b;--border:#334155;
+  --text:#f1f5f9;--text-sec:#94a3b8;--text-muted:#64748b;
+  --accent:#3b82f6;--accent-dim:#1e3a5f;
+  --sev-crit:#dc2626;--sev-high:#ea580c;--sev-med:#ca8a04;--sev-low:#0891b2;--sev-info:#6b7280;
+  --font:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  --mono:'SF Mono','Fira Code',Consolas,monospace;
+  --radius:8px
+}
 *{margin:0;padding:0;box-sizing:border-box}
-body{font-family:'Segoe UI',system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.6;padding:2rem}
-.container{max-width:1200px;margin:0 auto}
-h1{color:var(--accent);font-size:1.8rem;margin-bottom:.5rem}
-h2{color:var(--accent);font-size:1.3rem;margin:2rem 0 1rem;border-bottom:1px solid var(--card);padding-bottom:.5rem}
-.subtitle{color:var(--text-dim);font-size:.9rem;margin-bottom:2rem}
-.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;margin:1.5rem 0}
-.card{background:var(--surface);border:1px solid var(--card);border-radius:8px;padding:1.2rem}
-.card-label{font-size:.8rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.05em}
-.card-value{font-size:1.8rem;font-weight:700;margin-top:.3rem}
-.risk-score{text-align:center}
-.risk-ring{width:100px;height:100px;border-radius:50%;display:flex;align-items:center;justify-content:center;margin:0 auto;font-size:2rem;font-weight:700}
-table{width:100%;border-collapse:collapse;background:var(--surface);border-radius:8px;overflow:hidden;margin:1rem 0}
-th{background:var(--card);color:var(--accent);text-align:left;padding:.8rem 1rem;font-size:.85rem;text-transform:uppercase;letter-spacing:.03em}
-td{padding:.6rem 1rem;border-bottom:1px solid rgba(255,255,255,.05);font-size:.9rem}
-tr:hover{background:rgba(0,212,255,.03)}
-.sev-critical{color:#f44336;font-weight:700}
-.sev-high{color:#ff5722;font-weight:600}
-.sev-medium{color:#ff9800}
-.sev-low{color:#ffc107}
-.sev-info{color:#8888aa}
-.footer{text-align:center;color:var(--text-dim);font-size:.8rem;margin-top:3rem;padding-top:1rem;border-top:1px solid var(--card)}
+body{font-family:var(--font);background:var(--bg);color:var(--text);line-height:1.6}
+
+/* Sticky nav */
+nav{position:sticky;top:0;z-index:100;background:rgba(17,24,39,.95);backdrop-filter:blur(8px);border-bottom:1px solid var(--border);padding:.6rem 2rem;display:flex;gap:1.5rem;align-items:center;flex-wrap:wrap}
+nav a{color:var(--text-sec);text-decoration:none;font-size:.85rem;transition:color .2s}
+nav a:hover{color:var(--accent)}
+nav .brand{color:var(--accent);font-weight:700;font-size:1rem;margin-right:auto}
+
+.container{max-width:1300px;margin:0 auto;padding:2rem}
+h1{color:var(--accent);font-size:1.8rem;margin-bottom:.3rem}
+h2{color:var(--accent);font-size:1.3rem;margin:2.5rem 0 1rem;padding-bottom:.5rem;border-bottom:1px solid var(--border);cursor:pointer}
+h2:hover{opacity:.8}
+h2::before{content:'▼ ';font-size:.7rem;color:var(--text-muted)}
+h2.collapsed::before{content:'▶ ';font-size:.7rem}
+.section{transition:max-height .3s ease}
+.section.hidden{display:none}
+.subtitle{color:var(--text-muted);font-size:.9rem;margin-bottom:2rem}
+
+/* Cards */
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:1rem;margin:1.5rem 0}
+.card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.2rem;transition:border-color .2s}
+.card:hover{border-color:var(--accent)}
+.card-label{font-size:.75rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.card-value{font-size:1.6rem;font-weight:700;margin-top:.3rem}
+
+/* Risk gauge */
+.risk-gauge{text-align:center;padding:1.5rem}
+.risk-ring{width:120px;height:120px;border-radius:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;margin:0 auto;font-size:2.2rem;font-weight:800;transition:border-color .3s}
+.risk-label{font-size:.85rem;font-weight:600;margin-top:.2rem}
+
+/* Severity badges */
+.sev-badge{display:inline-block;padding:.15rem .6rem;border-radius:4px;font-size:.8rem;font-weight:600;text-transform:uppercase}
+.sev-critical{background:rgba(220,38,38,.15);color:var(--sev-crit)}
+.sev-high{background:rgba(234,88,12,.15);color:var(--sev-high)}
+.sev-medium{background:rgba(202,138,4,.15);color:var(--sev-med)}
+.sev-low{background:rgba(8,145,178,.15);color:var(--sev-low)}
+.sev-info{background:rgba(107,114,128,.15);color:var(--sev-info)}
+
+/* Severity count cards */
+.sev-grid{display:grid;grid-template-columns:repeat(5,1fr);gap:.8rem;margin:1rem 0}
+.sev-card{text-align:center;padding:.8rem;border-radius:var(--radius);background:var(--surface);border:1px solid var(--border)}
+.sev-card .count{font-size:1.8rem;font-weight:800}
+.sev-card .label{font-size:.75rem;text-transform:uppercase;letter-spacing:.05em;margin-top:.2rem}
+
+/* Tables */
+table{width:100%;border-collapse:collapse;background:var(--surface);border-radius:var(--radius);overflow:hidden;margin:1rem 0}
+th{background:var(--card);color:var(--accent);text-align:left;padding:.7rem 1rem;font-size:.8rem;text-transform:uppercase;letter-spacing:.04em;position:sticky;top:0}
+td{padding:.55rem 1rem;border-bottom:1px solid rgba(255,255,255,.04);font-size:.88rem}
+tr:hover{background:rgba(59,130,246,.04)}
+td a{color:var(--accent);text-decoration:none}
+td a:hover{text-decoration:underline}
+td code{font-family:var(--mono);font-size:.85rem;background:var(--card);padding:.1rem .4rem;border-radius:3px}
+
+/* Search/filter bar */
+.filter-bar{display:flex;gap:.8rem;margin:1rem 0;flex-wrap:wrap;align-items:center}
+.filter-bar input{background:var(--surface);border:1px solid var(--border);color:var(--text);padding:.5rem .8rem;border-radius:var(--radius);font-size:.88rem;flex:1;min-width:200px}
+.filter-bar input:focus{outline:none;border-color:var(--accent)}
+.filter-bar select{background:var(--surface);border:1px solid var(--border);color:var(--text);padding:.5rem;border-radius:var(--radius);font-size:.85rem}
+
+/* Footer */
+.footer{text-align:center;color:var(--text-muted);font-size:.8rem;margin-top:3rem;padding:1.5rem 0;border-top:1px solid var(--border)}
+.footer a{color:var(--accent);text-decoration:none}
+
+/* System info table */
+.sys-table{max-width:600px}
+.sys-table td:first-child{font-weight:600;color:var(--text-sec);width:180px}
 </style>
 </head>
 <body>
+<nav>
+  <span class="brand">IntrusionInspector</span>
+  <a href="#summary">Summary</a>
+  <a href="#mitre">MITRE</a>
+  <a href="#findings">Findings</a>
+  <a href="#system">System</a>
+  <a href="#collectors">Collectors</a>
+  <a href="#timeline">Timeline</a>
+  <a href="#" onclick="toggleAll();return false">Toggle All</a>
+</nav>
 <div class="container">
-<h1>IntrusionInspector Report</h1>
 HTMLEOF
 
-    # Append dynamic content — this heredoc is unquoted so bash variables
-    # (risk_score, findings_rows, collector_rows, etc.) are interpolated
+    # Part 2: Dynamic content with bash variable interpolation
     cat >> "$html_file" <<EOF
-<p class="subtitle">Generated $(utc_now) | v${VERSION}</p>
+
+<h1>IntrusionInspector Report</h1>
+<p class="subtitle">
+  Generated $(utc_now) &nbsp;|&nbsp; v${VERSION}
+  $( [[ -n "$case_id" ]] && echo "&nbsp;|&nbsp; Case: <strong>${case_id}</strong>" )
+  $( [[ -n "$examiner" ]] && echo "&nbsp;|&nbsp; Examiner: <strong>${examiner}</strong>" )
+</p>
+
+<!-- ═══════════ Executive Summary ═══════════ -->
+<div id="summary">
+<div class="grid">
+  <div class="card"><div class="card-label">Hostname</div><div class="card-value">${hostname_val:-—}</div></div>
+  <div class="card"><div class="card-label">Operating System</div><div class="card-value">${os_val:-—} ${os_version}</div></div>
+  <div class="card"><div class="card-label">Architecture</div><div class="card-value">${arch_val:-—}</div></div>
+  <div class="card"><div class="card-label">Kernel</div><div class="card-value">${kernel_val:-—}</div></div>
+</div>
 
 <div class="grid">
-<div class="card"><div class="card-label">Hostname</div><div class="card-value">${hostname_val:-—}</div></div>
-<div class="card"><div class="card-label">OS</div><div class="card-value">${os_val:-—}</div></div>
-<div class="card"><div class="card-label">Architecture</div><div class="card-value">${arch_val:-—}</div></div>
-<div class="card"><div class="card-label">Kernel</div><div class="card-value">${kernel_val:-—}</div></div>
+  <div class="card risk-gauge">
+    <div class="card-label">Risk Score</div>
+    <div class="risk-ring" style="border:5px solid ${risk_color}">${risk_score:-0}</div>
+    <div class="risk-label" style="color:${risk_color}">${risk_label}</div>
+    <div style="color:var(--text-muted);font-size:.75rem;margin-top:.3rem">out of ${MAX_RISK_SCORE}</div>
+  </div>
+  <div class="card"><div class="card-label">Total Findings</div><div class="card-value">${finding_count}</div></div>
+  <div class="card"><div class="card-label">MITRE Techniques</div><div class="card-value">${technique_count:-0}</div></div>
+  <div class="card"><div class="card-label">Total Artifacts</div><div class="card-value">${total_artifacts}</div></div>
 </div>
 
-<div class="grid">
-<div class="card risk-score">
-  <div class="card-label">Risk Score</div>
-  <div class="risk-ring" style="border: 4px solid ${risk_color}">${risk_score:-0}</div>
-  <div style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">/ ${MAX_RISK_SCORE}</div>
+<div class="sev-grid">
+  <div class="sev-card"><div class="count sev-critical">${count_critical}</div><div class="label">Critical</div></div>
+  <div class="sev-card"><div class="count sev-high">${count_high}</div><div class="label">High</div></div>
+  <div class="sev-card"><div class="count sev-medium">${count_medium}</div><div class="label">Medium</div></div>
+  <div class="sev-card"><div class="count sev-low">${count_low}</div><div class="label">Low</div></div>
+  <div class="sev-card"><div class="count sev-info">${count_info}</div><div class="label">Info</div></div>
 </div>
-<div class="card"><div class="card-label">Total Findings</div><div class="card-value">${finding_count}</div></div>
-<div class="card"><div class="card-label">MITRE Techniques</div><div class="card-value">${technique_count:-0}</div></div>
-<div class="card"><div class="card-label">Case ID</div><div class="card-value" style="font-size:1rem">${case_id:-—}</div></div>
 </div>
 
-<h2>Findings</h2>
+<!-- ═══════════ MITRE ATT&CK ═══════════ -->
+<h2 id="mitre" onclick="toggleSection('mitre-section')">MITRE ATT&CK Coverage</h2>
+<div id="mitre-section" class="section">
 <table>
-<thead><tr><th>Severity</th><th>Description</th><th>MITRE</th><th>Source</th></tr></thead>
+<thead><tr><th>Technique</th><th>Tactic</th><th>Count</th><th>Reference</th></tr></thead>
 <tbody>
-${findings_rows:-<tr><td colspan="4" style="text-align:center;color:var(--text-dim)">No findings</td></tr>}
+${mitre_rows:-<tr><td colspan="4" style="text-align:center;color:var(--text-muted)">No techniques detected</td></tr>}
 </tbody>
 </table>
+</div>
 
-<h2>Collection Summary</h2>
+<!-- ═══════════ Findings ═══════════ -->
+<h2 id="findings" onclick="toggleSection('findings-section')">Findings (${finding_count})</h2>
+<div id="findings-section" class="section">
+<div class="filter-bar">
+  <input type="text" id="findingsSearch" placeholder="Search findings..." onkeyup="filterFindings()">
+  <select id="severityFilter" onchange="filterFindings()">
+    <option value="">All Severities</option>
+    <option value="critical">Critical</option>
+    <option value="high">High</option>
+    <option value="medium">Medium</option>
+    <option value="low">Low</option>
+    <option value="info">Info</option>
+  </select>
+</div>
+<table id="findingsTable">
+<thead><tr><th>#</th><th>Severity</th><th>Description</th><th>MITRE</th><th>Source</th></tr></thead>
+<tbody>
+${findings_rows:-<tr><td colspan="5" style="text-align:center;color:var(--text-muted)">No findings</td></tr>}
+</tbody>
+</table>
+</div>
+
+<!-- ═══════════ System Overview ═══════════ -->
+<h2 id="system" onclick="toggleSection('system-section')">System Overview</h2>
+<div id="system-section" class="section">
+<table class="sys-table">
+<tbody>
+<tr><td>Hostname</td><td>${hostname_val:-—}</td></tr>
+<tr><td>OS</td><td>${os_val:-—} ${os_version}</td></tr>
+<tr><td>Architecture</td><td>${arch_val:-—}</td></tr>
+<tr><td>Kernel</td><td>${kernel_val:-—}</td></tr>
+<tr><td>CPU</td><td>${cpu_model:-—}</td></tr>
+<tr><td>RAM</td><td>${ram_mb:-—} MB</td></tr>
+<tr><td>Boot Time</td><td>${boot_time:-—}</td></tr>
+<tr><td>Uptime</td><td>${uptime_sec:-—} seconds</td></tr>
+<tr><td>Collection Start</td><td>${collection_start:-—}</td></tr>
+<tr><td>Collection End</td><td>${collection_end:-—}</td></tr>
+</tbody>
+</table>
+</div>
+
+<!-- ═══════════ Collectors ═══════════ -->
+<h2 id="collectors" onclick="toggleSection('collectors-section')">Collection Summary</h2>
+<div id="collectors-section" class="section">
 <table>
 <thead><tr><th>Collector</th><th>Artifacts</th><th>Duration</th></tr></thead>
 <tbody>
-${collector_rows:-<tr><td colspan="3" style="text-align:center;color:var(--text-dim)">No data</td></tr>}
+${collector_rows:-<tr><td colspan="3" style="text-align:center;color:var(--text-muted)">No data</td></tr>}
 </tbody>
 </table>
+</div>
+
+<!-- ═══════════ Timeline ═══════════ -->
+<h2 id="timeline" onclick="toggleSection('timeline-section')">Timeline</h2>
+<div id="timeline-section" class="section">
+<div class="filter-bar">
+  <input type="text" id="timelineSearch" placeholder="Search timeline..." onkeyup="filterTimeline()">
+</div>
+<table id="timelineTable">
+<thead><tr><th>Timestamp</th><th>Source</th><th>Type</th></tr></thead>
+<tbody>
+${timeline_rows:-<tr><td colspan="3" style="text-align:center;color:var(--text-muted)">No timeline data</td></tr>}
+</tbody>
+</table>
+</div>
 
 <div class="footer">
-IntrusionInspector v${VERSION} — Generated by bash DFIR tool<br>
-Examiner: ${examiner:-—}
+  <strong>IntrusionInspector</strong> v${VERSION} — Bash DFIR Triage Tool<br>
+  $( [[ -n "$examiner" ]] && echo "Examiner: ${examiner} &nbsp;|&nbsp;" )
+  $( [[ -n "$case_id" ]] && echo "Case: ${case_id} &nbsp;|&nbsp;" )
+  Report generated $(utc_now)
 </div>
 </div>
+EOF
+
+    # Part 3: JavaScript for interactivity (quoted heredoc — no expansion needed)
+    cat >> "$html_file" <<'JSEOF'
+<script>
+function toggleSection(id){
+  var s=document.getElementById(id);
+  if(s){s.classList.toggle('hidden')}
+  var h=s?s.previousElementSibling:null;
+  if(h&&h.tagName==='H2'){h.classList.toggle('collapsed')}
+}
+function toggleAll(){
+  var sections=document.querySelectorAll('.section');
+  var allHidden=true;
+  sections.forEach(function(s){if(!s.classList.contains('hidden'))allHidden=false});
+  sections.forEach(function(s){
+    if(allHidden){s.classList.remove('hidden')}else{s.classList.add('hidden')}
+  });
+  document.querySelectorAll('h2[onclick]').forEach(function(h){
+    if(allHidden){h.classList.remove('collapsed')}else{h.classList.add('collapsed')}
+  });
+}
+function filterFindings(){
+  var q=(document.getElementById('findingsSearch').value||'').toLowerCase();
+  var sev=document.getElementById('severityFilter').value;
+  var rows=document.querySelectorAll('#findingsTable .finding-row');
+  rows.forEach(function(r){
+    var text=r.textContent.toLowerCase();
+    var matchText=!q||text.indexOf(q)>=0;
+    var matchSev=!sev||r.getAttribute('data-severity')===sev;
+    r.style.display=(matchText&&matchSev)?'':'none';
+  });
+}
+function filterTimeline(){
+  var q=(document.getElementById('timelineSearch').value||'').toLowerCase();
+  var rows=document.querySelectorAll('#timelineTable .timeline-row');
+  rows.forEach(function(r){
+    r.style.display=(!q||r.textContent.toLowerCase().indexOf(q)>=0)?'':'none';
+  });
+}
+</script>
 </body>
 </html>
-EOF
+JSEOF
 
     log_info "HTML report written to ${html_file}"
 }


### PR DESCRIPTION
## Summary

Add IntrusionInspector (Bash Edition), a cross-platform DFIR triage tool that collects forensic artifacts from live macOS and Linux endpoints, analyzes them with anomaly detection, IOC/Sigma/YARA scanning, and MITRE ATT&CK mapping, and produces self-contained HTML, JSON, CSV, and console reports — all implemented in pure Bash 3.2+ with zero external dependencies.

## Changes
- [x] New feature
- [x] Documentation

### Core Implementation
- CLI entry point (`intrusion-inspector.sh`) with subcommands: `triage`, `collect`, `analyze`, `report`, `verify`
- Pipeline engine (`lib/engine.sh`) with convention-based dispatch for collectors, analyzers, and reporters
- 16 forensic artifact collectors (processes, network, persistence, browser history, USB devices, etc.)
- 6 analysis engines (anomaly detection, IOC/Sigma/YARA scanning, timeline, MITRE ATT&CK mapper)
- 4 report generators (self-contained HTML with dark theme, JSON, CSV super timeline, ANSI console)
- SHA-256 evidence integrity manifests and chain of custody tracking
- Pure-bash JSON builder (`lib/core/json.sh`) with no `jq` dependency
- Cross-platform support (macOS BSD + Linux GNU userland) with `platform.sh` wrappers
- Collection profiles (quick ~30s, standard ~2min, full ~5min with YARA)

### Documentation & Project Setup
- Comprehensive README with architecture diagram, usage guide, and MITRE ATT&CK coverage table
- AGENTS.md for AI-assisted development with code conventions, architecture, and common tasks
- CONTRIBUTING.md with development workflow, coding standards, and extension guides
- GitHub PR and issue templates (bug report, feature request)
- `justfile` with recipes for triage, development, and cleanup
- OWNERS.yaml for code ownership

## Test Plan
- [x] `just lint` passes (all scripts pass `bash -n` syntax check)
- [x] Tested on macOS
- [x] Tested on Linux
- [x] Manual triage run completed (`just quick`)

## Cross-Platform Considerations
All scripts target Bash 3.2+ for macOS compatibility. No associative arrays, no `${var,,}` lowercasing. Platform-specific commands are wrapped via `has_cmd` checks and `platform.sh` utility functions. Collectors handle both BSD and GNU tool variants.

## Security Considerations
Evidence integrity is maintained via SHA-256 manifests. Chain of custody metadata records case ID, examiner, and timestamps. Optional encrypted packaging uses `zip -P` for evidence transport. The tool requires root access for artifact collection (system logs, process tables, privileged paths).


Made with [Cursor](https://cursor.com)